### PR TITLE
Fix schema validation: replace oneOf with anyOf for numeric union types.

### DIFF
--- a/vcon_json_schema.json
+++ b/vcon_json_schema.json
@@ -219,20 +219,20 @@
           "description": "Start time of the dialog in RFC3339 format"
         },
         "duration": {
-          "oneOf": [
+          "anyOf": [
             {"type": "integer", "minimum": 0},
             {"type": "number", "minimum": 0}
           ],
           "description": "Duration in seconds"
         },
         "parties": {
-          "oneOf": [
+          "anyOf": [
             {"type": "integer", "minimum": 0},
             {"type": "array", "items": {"type": "integer", "minimum": 0}},
             {
               "type": "array",
               "items": {
-                "oneOf": [
+                "anyOf": [
                   {"type": "integer", "minimum": 0},
                   {"type": "array", "items": {"type": "integer", "minimum": 0}}
                 ]
@@ -502,4 +502,3 @@
     }
   }
 }
-


### PR DESCRIPTION
This PR corrects the JSON Schema validation logic for the `Dialog` object by replacing `oneOf` constraints with `anyOf` where appropriate.

### Changes
- **`duration` field**: Changed from `oneOf` to `anyOf` to allow both `integer` and `number` types
- **`parties` field**: Changed from `oneOf` to `anyOf` for the top-level union and nested array items

### Rationale
The `oneOf` constraint requires that the value matches **exactly one** schema, which can fail when a value like `0` or `1` could satisfy both integer and number types. Using `anyOf` is more appropriate here because:

1. **`duration`**: A value like `5` is both a valid integer and a valid number in JSON Schema, causing `oneOf` validation to fail.
2. **`parties`**: Similar issue with numeric indices, they should be accepted as long as they satisfy at least one valid schema pattern.

The `anyOf` constraint allows the value to match **one or more** schemas, which is the correct semantic for these union types where overlapping types are acceptable.
